### PR TITLE
chore(pi): model metadata + misc agent tooling updates

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -15,7 +15,8 @@
   br = branch
   co = checkout
   d = diff
-  lg = log
+  dhead = diff HEAD --
+  dlast = diff HEAD~1 --
   l = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
   ld = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit -p
   append = commit --amend -C HEAD

--- a/gitconfig
+++ b/gitconfig
@@ -15,8 +15,8 @@
   br = branch
   co = checkout
   d = diff
-  dhead = diff HEAD --
-  dlast = diff HEAD~1 --
+  dhead = diff HEAD
+  dlast = diff HEAD~1 HEAD
   l = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
   ld = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit -p
   append = commit --amend -C HEAD

--- a/pi/agent/AGENTS.md
+++ b/pi/agent/AGENTS.md
@@ -11,3 +11,7 @@ Install with:
   pi install npm:pi-subagents
   pi install npm:pi-ask-user
 <!-- END COMPOUND PI TOOL MAP -->
+
+## Git identity safety
+
+Do not change or override `git user.name` or `git user.email` without explicit user approval. This includes persistent config changes (`git config user.name ...`, `git config user.email ...`) and command-local overrides (`git -c user.name=...`, `git -c user.email=...`). Use the existing repository/user Git identity by default.

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,6 +1,6 @@
 {
-  "defaultModel": "gpt-5.5",
-  "defaultProvider": "openai-codex",
+  "defaultModel": "MiniMax-M3",
+  "defaultProvider": "minimax",
   "compaction": {
     "reserveTokens": 16384,
     "keepRecentTokens": 24000

--- a/pi/agent/skills/agents-md-optimizer/SKILL.md
+++ b/pi/agent/skills/agents-md-optimizer/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: agents-md-optimizer
+description: "Optimize agent context files (AGENTS.md, CLAUDE.md, .cursorrules, .windsurfrules, .github/copilot-instructions.md, codex.md, etc.) using Addy Osmani's agents-md methodology. Triggers: 'optimize CLAUDE.md', 'streamline CLAUDE.md', 'agents-md', 'discoverability filter', 'add gotchas', 'optimize AGENTS.md', 'optimize context file', 'CLAUDE.md 최적화', 'CLAUDE.md 줄이기', 'CLAUDE.md 다이어트', 'optimize .cursorrules', 'optimize .windsurfrules', 'optimize copilot-instructions', 'optimize codex.md'."
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
+---
+
+# Agents-MD Optimizer
+
+Optimize agent context files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) by applying the discoverability filter: remove information agents can discover from code, keep only non-discoverable operational knowledge (gotchas, landmines, non-standard conventions), and mine source code for undocumented gotchas.
+
+Research shows redundant context (directory trees, data flow diagrams) degrades agent performance by 15-20%, while human-authored operational knowledge reduces runtime by ~28%.
+
+## Flag Parsing
+
+Parse `$ARGUMENTS` for optional flags:
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Analyze and show diff without modifying the file |
+| `--report-only` | Output statistics and classification table only |
+| `--path <path>` | Target file path (see auto-detection below) |
+| `--help` | Display usage and exit |
+
+If `--help` is present, display available flags and a brief description of the workflow, then stop.
+
+## Workflow
+
+### Phase 0: Setup
+
+**Language Detection**: Detect the user's language from conversation history. Present all analysis results and messages in the user's language.
+
+**Target File Resolution** (when `--path` is not specified):
+
+Search for the first existing file in this priority order:
+1. `AGENTS.md`
+2. `CLAUDE.md`
+3. `.cursorrules`
+4. `CURSOR.md`
+5. `.github/copilot-instructions.md`
+6. `.windsurfrules`
+7. `codex.md`
+
+If none found, ask the user to specify the target file path.
+
+**Small File Check**: If the target file has fewer than 20 lines, inform the user that the file is already minimal and optimization is unnecessary. Stop unless the user explicitly requests to proceed.
+
+### Step 1: Baseline Analysis
+
+Read the target file. Collect line statistics.
+
+**Script Location**: Find the line-count script by searching for it:
+
+```bash
+# Search in common skill installation paths
+SCRIPT_PATH=$(find ~/.claude/skills ~/.codex/skills ~/.cursor/skills ~/skills 2>/dev/null -path "*/agents-md-optimizer/scripts/line-count.mjs" | head -1)
+if [ -z "$SCRIPT_PATH" ]; then
+  # Fallback: search in current directory
+  SCRIPT_PATH=$(find . -path "*/agents-md-optimizer/scripts/line-count.mjs" 2>/dev/null | head -1)
+fi
+```
+
+Run the script if found:
+
+```bash
+node "$SCRIPT_PATH" '<TARGET_PATH>'
+```
+
+**Fallback** (if script not found): Count lines manually using Bash:
+
+```bash
+wc -l '<TARGET_PATH>'
+grep -c '^##' '<TARGET_PATH>'
+```
+
+Then classify each `##`/`###` section into one of three categories:
+
+| Category | Meaning | Action |
+|----------|---------|--------|
+| `discoverable` | Agent can find this via Glob/Grep/Read within 10 seconds | Remove |
+| `operational` | Non-discoverable, operationally significant | Keep |
+| `verbose` | Operational knowledge but overly detailed | Compress |
+
+To classify, **actually read the source files** referenced in each section. Verify whether the information is truly discoverable. Detailed classification criteria are in [`references/methodology.md`](references/methodology.md).
+
+Present results as a table:
+
+```
+## Baseline Analysis — <filename>
+
+Total: XXX lines (YY sections)
+
+| Section | Lines | Category | Rationale |
+|---------|-------|----------|-----------|
+| Directory Structure | 63 | discoverable | Glob **/* reveals this instantly |
+| Design Rules | 8 | operational | Non-standard constraints, not in code |
+| Config & State | 24 | verbose | Operational but compressible to ~6 lines |
+
+Removal candidates: XX lines (XX%)
+```
+
+If `--report-only`, stop here.
+
+### Step 2: Gotcha Mining
+
+Scan project source code to find non-obvious operational knowledge missing from the target file. Use the systematic checklist in [`references/gotcha-mining.md`](references/gotcha-mining.md).
+
+Key Grep patterns to run on the codebase:
+
+```
+MUST|WARNING|HACK|TODO|FIXME          → developer-flagged gotchas
+catch.*exit\(0\)|process\.exit        → error exit policies
+setTimeout|setInterval|deadline       → timing constraints
+=== null|== null|delete result        → implicit semantics
+process\.platform|/proc/version       → platform detection quirks
+cooldown|throttle|lastNotified        → rate limiting scope
+```
+
+Present findings:
+
+```
+## Discovered Gotchas
+
+| # | Category | Description | Source | Already documented? |
+|---|----------|-------------|--------|---------------------|
+| 1 | Timing | 5s→4s→2s budget | _common.mjs:21,52 | No → Add |
+| 2 | Implicit | null = key deletion | config.mjs:157 | No → Add |
+```
+
+### Step 3: Generate Optimized File
+
+Use AskUserQuestion to confirm before modifying:
+
+> Based on the analysis:
+> - **Remove**: X lines of discoverable content (Y sections)
+> - **Compress**: X lines → ~Y lines (Z sections)
+> - **Add**: X new gotcha items
+>
+> Options:
+> 1. **Apply all** — Remove discoverable, compress verbose, add gotchas
+> 2. **Item by item** — Review each change individually
+> 3. **Cancel** — No changes
+
+Apply the selected changes using Edit (prefer surgical edits over full rewrite).
+
+If `--dry-run`, show the diff but do not write.
+
+**Structure for optimized file** (recommended section order):
+1. Project description (1-2 lines)
+2. Development Commands
+3. Design Rules (non-negotiable constraints)
+4. Gotchas & Landmines (categorized subsections)
+5. Conventions (non-standard project patterns)
+6. Version/Release Management
+7. Testing
+
+Detailed anti-pattern examples with before/after are in [`references/anti-patterns.md`](references/anti-patterns.md).
+
+### Step 4: Verification
+
+Re-run statistics (using the same script or fallback method from Step 1) and present before/after comparison:
+
+```
+## Optimization Results
+
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| Total lines | 182 | 90 | -51% |
+| Discoverable lines | 80 | 0 | Removed |
+| Operational lines | 60 | 55 | Kept |
+| Gotcha items | 0 | 25 | Added |
+
+Discoverability filter: all remaining lines pass "not discoverable from code" check.
+```
+
+## Reference Files
+
+- **[`references/methodology.md`](references/methodology.md)** — Discoverability filter decision tree, category classification criteria, compression techniques, efficiency research data
+- **[`references/anti-patterns.md`](references/anti-patterns.md)** — 6 anti-pattern catalog with real before/after examples
+- **[`references/gotcha-mining.md`](references/gotcha-mining.md)** — 8-category mining checklist with Grep patterns and source code analysis techniques

--- a/pi/agent/skills/agents-md-optimizer/references/anti-patterns.md
+++ b/pi/agent/skills/agents-md-optimizer/references/anti-patterns.md
@@ -1,0 +1,176 @@
+# Anti-Pattern Catalog
+
+Patterns commonly found in CLAUDE.md files that should be removed or compressed.
+Each pattern is illustrated with real examples from the dding-dong project optimization (182 → 90 lines, 51% reduction).
+
+## Anti-Pattern #1: Directory Structure Tree
+
+**Why discoverable:** `ls -la`, `Glob **/*`, or `tree` reveals the entire structure instantly.
+
+**Before (63 lines):**
+```
+### Directory Structure
+
+hooks/                 # Claude Code hook entry points (.mjs)
+  hooks.json           # Hook registration manifest
+  _common.mjs          # Shared runHook() utility
+  notification.mjs     # Notification hook → input.required
+  stop.mjs             # Stop hook → task.complete
+skills/
+  dd-config/
+    SKILL.md           # /dding-dong:dd-config - settings management
+    scripts/
+      config-get.mjs   # Config key reader
+      config-set.mjs   # Config key writer
+  ...                  # (50+ more lines)
+```
+
+**After:** Entire section deleted. Zero lines.
+
+**Exception:** Keep a directory note only if the structure is *counter-intuitive* or violates convention (e.g., "Tests live in `src/` next to source files, not in `test/`").
+
+## Anti-Pattern #2: Data Flow Diagram
+
+**Why discoverable:** Following `import` chains from entry points reveals the exact flow.
+
+**Before (16 lines):**
+```
+### Data Flow
+
+Hook event → hooks/*.mjs
+  → _common.mjs runHook(eventType, options)
+    → stdin parse (JSON event)
+    → scripts/notify.mjs notify(eventType, context)
+      → loadConfig(cwd)
+      → config.enabled check
+      → isQuietHours() check
+      → loadState()
+      → isCoolingDown() check
+      → playSound() + sendNotification()
+      → saveState()
+    → optional stdout response
+```
+
+**After:** Entire section deleted. Zero lines.
+
+**Exception:** Keep if the flow has a non-obvious *constraint* (e.g., "playSound and sendNotification must run in parallel via Promise.allSettled, never sequential").
+
+## Anti-Pattern #3: Tech Stack / "X uses Y" Descriptions
+
+**Why discoverable:** Import statements, `package.json`, and file extensions are self-documenting.
+
+**Before:**
+```
+- `player.mjs` uses `spawn` from `node:child_process` for audio playback
+- `notifier.mjs` uses `execFileSync` for OS notifications
+- All scripts use ESM with `.mjs` extension
+```
+
+**After:** Only the non-obvious rule survives:
+```
+- **ESM only**: All scripts use `.mjs` extension with `import`/`export` syntax.
+```
+
+This survives because it's a *project convention* that could be violated (someone might add a `.js` file), not a description of what exists.
+
+## Anti-Pattern #4: Config Path Listings
+
+**Why discoverable:** Config modules export path constants; reading the module reveals all paths.
+
+**Before (24 lines):**
+```
+### Config & State Files
+
+Config is loaded via 5-stage merge (later stages override earlier):
+1. **Default** — hardcoded `DEFAULT_CONFIG` in `config.mjs`
+2. **Global** — `~/.config/dding-dong/config.json`
+3. **Project** — `.dding-dong/config.json` (team-shared, committed)
+4. **Project Local** — `.dding-dong/config.local.json` (personal override, gitignored)
+5. **Env vars** — `DDING_DONG_ENABLED`, `DDING_DONG_VOLUME`, ...
+
+Other paths:
+- State: `~/.config/dding-dong/.state.json`
+- Project sound packs: `.dding-dong/packs/<pack-name>/manifest.json`
+- User sound packs: `~/.config/dding-dong/packs/<pack-name>/manifest.json`
+- Backup files: `<config-path>.backup.<YYYYMMDD_HHMMSS>` (max 3)
+
+#### `_meta` field convention
+The `_meta` field in the global config stores setup metadata:
+{ "_meta": { "setupCompleted": true, ... } }
+- Stored in: Global config only
+- Merge behavior: Isolated from deepMerge
+- Usage: doctor skill checks _meta.setupCompleted
+```
+
+**After (6 lines in Gotchas > Config):**
+```
+### Config
+- 5-stage merge (later wins): Default ← Global ← Project ← Local ← env vars
+- `_meta`: extracted before deepMerge, re-attached after. Global-only. Cannot be polluted by project config
+- `null` in deepMerge = key deletion. `{ "sound": null }` → removes the sound key entirely. To disable, use `{ "sound": { "enabled": false } }`
+- Project/Local scopes store diff-only overrides (not full snapshots)
+- `saveConfig` runs round-trip `JSON.parse` validation. On failure, auto-restores from backup
+- Backups: max 3 per config file, oldest auto-deleted
+```
+
+The paths are discoverable; the *behaviors* (null deletion, _meta isolation, diff-only, round-trip validation) are not.
+
+## Anti-Pattern #5: Cross-Platform Table
+
+**Why discoverable:** Platform detection code explicitly lists all platforms and their tools.
+
+**Before (9 lines):**
+```
+### Cross-Platform Strategy
+
+| Platform | Sound Playback | OS Notification |
+|----------|---------------|-----------------|
+| macOS    | `afplay`      | `osascript`     |
+| Linux    | `pw-play` > `paplay` > `ffplay` > `mpv` > `aplay` | `notify-send` |
+| WSL      | PowerShell `MediaPlayer` | `wsl-notify-send` > WinRT Toast > terminal bell |
+```
+
+**After (3 lines in Gotchas > Platform):**
+```
+### Platform
+- WSL detection: checks `/proc/version` for "microsoft" (case-insensitive). `process.platform` returns `"linux"` even on WSL
+- Linux audio priority: `pw-play` > `paplay` > `ffplay` > `mpv` > `aplay`
+- WSL notification priority: `wsl-notify-send` > WinRT PowerShell Toast > terminal bell
+```
+
+macOS entries are removed (standard, discoverable). WSL detection gotcha is added (non-obvious). Priority orders are kept (require reading implementation to determine order).
+
+## Anti-Pattern #6: Event Type Enumerations
+
+**Why discoverable:** Grep for event definitions in hooks.json or message files reveals all types.
+
+**Before:**
+```
+### Event Types
+
+`task.complete`, `task.error`*, `input.required`, `session.start`, `session.end`
+
+> *`task.error` is defined in config/messages but has no triggering hook.
+```
+
+**After (1 line in Gotchas > Events):**
+```
+### Events
+- `task.error`: defined in config/messages but has no triggering hook. Only testable via CLI test mode.
+```
+
+The enumeration is removed; only the *caveat* (no triggering hook) survives because it requires cross-referencing hooks.json with messages.mjs.
+
+## Decision Flowchart
+
+For each section in CLAUDE.md:
+
+```
+Is this information discoverable via ls/Glob/Grep/Read?
+├── Yes → DELETE the section
+├── No → Is it expressed concisely (≤3 lines)?
+│   ├── Yes → KEEP as-is
+│   └── No → COMPRESS to essential gotcha bullets
+└── Partially (fact exists but implication doesn't)
+    → REWRITE as a gotcha (state the non-obvious implication)
+```

--- a/pi/agent/skills/agents-md-optimizer/references/gotcha-mining.md
+++ b/pi/agent/skills/agents-md-optimizer/references/gotcha-mining.md
@@ -1,0 +1,181 @@
+# Gotcha Mining Checklist
+
+Systematic process for discovering non-obvious operational knowledge hidden in source code. Each category includes what to look for, Grep patterns, and examples from the dding-dong project.
+
+## Mining Process
+
+1. Identify the project's core modules (entry points, config, platform abstraction)
+2. For each module, scan using the category checklists below
+3. For each finding, ask: "Is this already in CLAUDE.md?" and "Would an agent get this wrong without being told?"
+4. Document findings with source file and line reference
+
+## Category 1: Timing & Ordering Constraints
+
+Hidden time budgets, sequencing requirements, and race conditions.
+
+**Grep patterns:**
+```
+setTimeout|setInterval|deadline|timeout|budget
+Promise\.race|Promise\.allSettled
+```
+
+**What to look for:**
+- Nested timeouts that create a timing budget (outer timeout minus inner timeout = remaining budget)
+- Operations that must complete within a time window
+- Specific ordering of async operations
+
+**dding-dong example:**
+- `hooks/_common.mjs`: hooks.json 5s timeout → internal safety timer 4s → stdin read 2s → only ~2s left for notify()
+- This timing *budget* is invisible from any single line of code — it emerges from the interaction of three separate timeouts
+
+## Category 2: Implicit Semantics
+
+Values that mean something unexpected, special-cased behavior.
+
+**Grep patterns:**
+```
+=== null|== null|delete .+\[|delete result
+deepMerge|Object\.assign|structuredClone
+```
+
+**What to look for:**
+- `null` used as a sentinel (deletion, reset, bypass)
+- Merge functions with special handling for specific values
+- Default values that override or get overridden unexpectedly
+
+**dding-dong example:**
+- `config.mjs:157`: `null` in deepMerge triggers `delete result[key]` — setting `{ "sound": null }` doesn't set sound to null, it *removes* the sound key entirely
+- Trap: a developer trying to "clear" a config value with null accidentally deletes the entire subtree
+
+## Category 3: Platform Detection Gotchas
+
+Cases where platform detection behaves non-obviously.
+
+**Grep patterns:**
+```
+process\.platform|os\.platform|/proc/version
+wsl|microsoft|darwin|win32
+```
+
+**What to look for:**
+- WSL reporting as "linux" in `process.platform`
+- Platform-specific paths or commands that differ from expectations
+- Detection methods that use file contents instead of standard APIs
+
+**dding-dong example:**
+- `platform.mjs:14`: WSL detected via `/proc/version` containing "microsoft" (case-insensitive), because `process.platform` returns `"linux"` on WSL
+- Without this gotcha, an agent would treat WSL as standard Linux and use wrong audio/notification tools
+
+## Category 4: Mandatory Response Contracts
+
+Entry points that MUST produce specific output or the system blocks.
+
+**Grep patterns:**
+```
+stdout\.write|process\.stdout|respond|response
+MUST|must write|must respond|required.*output
+```
+
+**What to look for:**
+- Hook handlers that must write to stdout (blocking callers await the response)
+- API endpoints with mandatory response shapes
+- IPC protocols requiring acknowledgment
+
+**dding-dong example:**
+- `hooks/_common.mjs`: stop hook MUST write `{}` to stdout — Claude Code waits for this response. Missing it halts execution
+- Safety net: `uncaughtException` handler writes the response before exiting, ensuring Claude never blocks
+
+## Category 5: Error Exit Policies
+
+Non-standard error handling where errors are intentionally swallowed.
+
+**Grep patterns:**
+```
+catch.*exit\(0\)|catch.*\{\s*\}|process\.exit\(0\)
+// ignore|// silent|// swallow
+```
+
+**What to look for:**
+- `exit(0)` in catch blocks (errors intentionally don't propagate)
+- Empty catch blocks with comments explaining why
+- Design decisions where failure of a subsystem must not affect the parent
+
+**dding-dong example:**
+- All hook catch blocks call `process.exit(0)` — notification failure must never block Claude Code
+- `detached: true` + `.unref()` pattern: audio processes are fire-and-forget to meet the 5s hook timeout
+
+## Category 6: Hidden Configuration Rules
+
+Configuration behaviors that aren't apparent from the config schema alone.
+
+**Grep patterns:**
+```
+_meta|\.meta|internal|private|reserved
+diff.only|override|merge.*before|merge.*after
+backup|restore|rollback
+```
+
+**What to look for:**
+- Fields extracted/re-attached around merge operations (isolation patterns)
+- Config scopes that store partial data (diffs vs snapshots)
+- Automatic backup/restore mechanisms
+
+**dding-dong example:**
+- `config.mjs:178-184,219`: `_meta` field extracted before deepMerge, re-attached after — prevents project config from overwriting global setup metadata
+- `config.mjs:227`: Project/Local scopes store diff-only overrides, not full config snapshots
+- `config.mjs:250-256`: Round-trip JSON.parse validation after save; on failure, auto-restores from backup
+
+## Category 7: Cooldown & Deduplication
+
+Rate limiting or deduplication logic with non-obvious scope.
+
+**Grep patterns:**
+```
+cooldown|throttle|debounce|rate.limit
+lastNotified|lastRun|lastExec|timestamp
+```
+
+**What to look for:**
+- Cooldowns that are global vs per-event vs per-source
+- Timestamps that prevent expected operations from firing
+- Edge cases where rapid successive events suppress each other
+
+**dding-dong example:**
+- `config.mjs:43`: Single global `cooldown_seconds: 3` with one `lastNotifiedAt` timestamp
+- Gotcha: a `task.complete` notification suppresses a `session.start` notification that follows within 3 seconds — the cooldown is global, not per-event-type
+
+## Category 8: Reserved / Unimplemented Features
+
+Defined interfaces with no actual implementation or trigger.
+
+**Grep patterns:**
+```
+TODO|FIXME|HACK|XXX|DEPRECATED
+reserved|future|placeholder|not.yet|unimplemented
+```
+
+**What to look for:**
+- Event types defined in config/messages but with no corresponding hook
+- API routes declared but not wired to handlers
+- Feature flags that are always false
+
+**dding-dong example:**
+- `task.error` event: defined in `DEFAULT_CONFIG.sound.events`, has messages in `messages.mjs`, but no hook in `hooks.json` triggers it
+- Only testable via CLI `test` mode. Reserved for future Claude Code error hook support
+
+## Mining Summary Template
+
+After scanning, organize findings in this format:
+
+```markdown
+## Discovered Gotchas
+
+| # | Category | Description | Source | In CLAUDE.md? |
+|---|----------|-------------|--------|---------------|
+| 1 | Timing | 5s→4s→2s budget leaves ~2s for notify() | _common.mjs:21,52 | No → Add |
+| 2 | Implicit | null = key deletion in deepMerge | config.mjs:157 | No → Add |
+| 3 | Platform | WSL detected via /proc/version, not process.platform | platform.mjs:14 | No → Add |
+| ... | ... | ... | ... | ... |
+```
+
+This table drives Step 3 (optimization) of the skill workflow.

--- a/pi/agent/skills/agents-md-optimizer/references/methodology.md
+++ b/pi/agent/skills/agents-md-optimizer/references/methodology.md
@@ -1,0 +1,110 @@
+# Discoverability Filter Methodology
+
+Based on Addy Osmani's [agents-md](https://addyosmani.com/blog/agents-md/) blog post and supporting research.
+
+## Core Principle
+
+> "Can the agent find this by reading the code? If yes, delete it."
+
+CLAUDE.md should contain only information that is:
+1. **Non-discoverable** — cannot be found by reading source code, running `ls`, or following imports
+2. **Operationally significant** — changes how the agent executes tasks
+3. **Impossible to guess** — not inferable from standard conventions
+
+## The 10-Second Rule
+
+For each line in CLAUDE.md, ask: "Can an agent discover this using Glob, Grep, or Read within 10 seconds?"
+
+- **Yes** → Mark as `discoverable` → Remove
+- **No, but the info is correct** → Mark as `operational` → Keep
+- **Partially** — the fact exists in code but the *implication* doesn't → Mark as `verbose` → Compress
+
+## Category Classification
+
+### Discoverable (Remove)
+
+Information agents find automatically through standard exploration:
+
+| Pattern | How Agent Discovers It |
+|---------|----------------------|
+| Directory structure trees | `ls -la`, `Glob **/*` |
+| Data flow diagrams | Follow `import`/`require` chains |
+| Tech stack descriptions | `package.json`, file extensions, imports |
+| "X uses Y" explanations | Import statements are self-documenting |
+| File-by-file descriptions | Reading the file itself is faster than reading about it |
+| Architecture overviews | Module boundaries visible from directory + imports |
+| Event/type enumerations | Grep for type definitions, enum values |
+| Config path listings | Constants in config modules |
+| Standard build steps | `package.json` scripts, `Makefile` targets |
+| Dependency relationships | `import` graph traversal |
+
+### Operational (Keep)
+
+Information that requires human experience to know:
+
+| Pattern | Why Not Discoverable |
+|---------|---------------------|
+| Timing constraints | Timeout values exist in code but their *budget allocation* across stages isn't obvious |
+| Mandatory response contracts | Code shows `stdout.write()` but not *why* it's critical (e.g., blocks Claude) |
+| Null semantics in merge | `delete result[key]` exists but the design choice that "null = deletion" is a gotcha |
+| Error exit policies | `exit(0)` in catch blocks exists but the rule "never block Claude" is a design decision |
+| Platform detection gotchas | Code checks `/proc/version` but the fact that `process.platform === "linux"` on WSL is a trap |
+| Cooldown scope decisions | Single timestamp exists but "global, not per-event" is a design choice |
+| Commit ordering conventions | No code enforces "feature commit first, then version bump" |
+| Non-standard tool choices | `uv` vs `pip`, `bun` vs `npm` — convention, not discoverable |
+| Reserved/unimplemented features | Defined in config but no hook exists — requires cross-referencing multiple files |
+
+### Verbose (Compress)
+
+Operational knowledge expressed in too many lines:
+
+**Indicators:**
+- Config merge explanation spanning 10+ lines → Compress to 1-line summary with stage order
+- Cross-platform table with obvious entries → Keep only non-obvious platforms (e.g., WSL)
+- Multi-paragraph explanations of backup behavior → Compress to "max N, auto-rotated"
+
+**Compression Techniques:**
+- **Table → bullet**: Convert multi-row tables to single-line `key: value` bullets
+- **Paragraph → condition-result**: "When X happens, Y occurs" in one line
+- **Enumeration → range**: "5 event types: ..." → Only mention the one with a caveat
+- **Section → subsection**: Promote to parent section's bullet point
+
+## Efficiency Data
+
+Research findings supporting this methodology:
+
+| Study | Finding |
+|-------|---------|
+| Lulla et al. (2026) | Human-authored AGENTS.md reduced wall-clock runtime by **28.64%** and token consumption by **16.58%** |
+| ETH Zurich | LLM-generated context files **reduced** task success by 2-3% while **increasing** cost by 20%+ |
+| Arize AI | Automated refinement of agent instructions achieved +5.19% accuracy improvement |
+
+Key insight: **Adding information can hurt performance.** Redundant context forces agents to process the same information twice, consuming tokens and increasing latency without improving accuracy.
+
+## The Pink Elephant Problem
+
+Mentioning a deprecated pattern anchors the model toward it. If CLAUDE.md says "Don't use the old auth module," the agent becomes more likely to reference it. Instead:
+- Delete mentions of deprecated code entirely
+- If the agent encounters it, it will ask or investigate — which is the correct behavior
+
+## Maintenance Philosophy
+
+> "AGENTS.md is a living list of codebase smells you haven't fixed yet, not a permanent configuration."
+
+Implications:
+- When a gotcha is fixed in code, remove it from CLAUDE.md
+- Periodically audit: "Is this still true? Is this still non-discoverable?"
+- Prefer fixing the code over documenting the gotcha
+- Start nearly empty, add only what causes agent confusion
+
+## Section Structure for Optimized CLAUDE.md
+
+Recommended sections (in order):
+
+1. **Project description** — 1-2 lines, what the project does + key constraint (e.g., "zero dependencies")
+2. **Development Commands** — Scripts and their purposes (not discoverable from code alone)
+3. **Design Rules** — Non-negotiable constraints that cause failures if violated
+4. **Gotchas & Landmines** — Categorized by domain (timing, config, platform, etc.)
+5. **Conventions** — Non-standard patterns specific to this project
+6. **Version/Release** — Workflow that can't be inferred from code
+7. **Testing** — Framework choice and priorities (especially if no tests exist yet)

--- a/pi/agent/skills/agents-md-optimizer/scripts/line-count.mjs
+++ b/pi/agent/skills/agents-md-optimizer/scripts/line-count.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * CLAUDE.md line count and section statistics
+ * Usage: node line-count.mjs <path-to-claude-md>
+ * Output: JSON with total lines, sections, code blocks, tables
+ * Exit codes: 0 = success, 1 = error
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const filePath = process.argv[2];
+
+if (!filePath) {
+  console.error(JSON.stringify({ error: 'No file path provided', usage: 'node line-count.mjs <path-to-file>' }));
+  process.exit(1);
+}
+
+const resolvedPath = resolve(filePath);
+
+if (!existsSync(resolvedPath)) {
+  console.error(JSON.stringify({ error: `File not found: ${resolvedPath}` }));
+  process.exit(1);
+}
+
+let content;
+try {
+  content = readFileSync(resolvedPath, 'utf8');
+} catch (err) {
+  console.error(JSON.stringify({ error: `Cannot read file: ${err.message}` }));
+  process.exit(1);
+}
+
+const lines = content.split('\n');
+const totalLines = lines.length;
+const nonEmptyLines = lines.filter(l => l.trim().length > 0).length;
+
+const sections = [];
+let currentSection = null;
+let inCodeBlock = false;
+let codeBlockLines = 0;
+let tableLines = 0;
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+
+  // Track code blocks
+  if (line.trimStart().startsWith('```')) {
+    inCodeBlock = !inCodeBlock;
+    codeBlockLines++;
+    if (currentSection) currentSection.codeBlockLines++;
+    continue;
+  }
+
+  if (inCodeBlock) {
+    codeBlockLines++;
+    if (currentSection) currentSection.codeBlockLines++;
+    continue;
+  }
+
+  // Track tables
+  if (/^\s*\|.*\|/.test(line)) {
+    tableLines++;
+    if (currentSection) currentSection.tableLines++;
+    continue;
+  }
+
+  // Detect headings (## or ###)
+  const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+  if (headingMatch) {
+    const level = headingMatch[1].length;
+    if (level >= 2) {
+      if (currentSection) {
+        currentSection.endLine = i;
+        currentSection.lines = currentSection.endLine - currentSection.startLine;
+        sections.push(currentSection);
+      }
+      currentSection = {
+        heading: headingMatch[2].trim(),
+        level,
+        startLine: i + 1,
+        endLine: null,
+        lines: 0,
+        codeBlockLines: 0,
+        tableLines: 0
+      };
+    }
+  }
+}
+
+// Close last section
+if (currentSection) {
+  currentSection.endLine = totalLines;
+  currentSection.lines = currentSection.endLine - currentSection.startLine;
+  sections.push(currentSection);
+}
+
+const result = {
+  file: resolvedPath,
+  totalLines,
+  nonEmptyLines,
+  codeBlockLines,
+  tableLines,
+  sectionCount: sections.length,
+  sections
+};
+
+console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
## Summary

Five discrete commits on `chore/pi-model-metadata`:

- **30e2327** `chore(gitconfig): replace lg alias with dhead/dlast diff shortcuts`
- **177eb11** `chore(pi): add Git identity safety guidance to AGENTS.md`
- **3eb1076** `chore(pi): switch default model to MiniMax-M3 on minimax provider`
- **de2b1cb** `feat(pi): add agents-md-optimizer skill`
- **95b09e4** `fix(gitconfig): make dhead/dlast aliases accept flags and pathspecs` — follow-up that fixes two issues found during manual verification (see below)

## Follow-up: 30e2327 had two bugs

Reviewing the `dhead` / `dlast` aliases exposed:

1. The trailing `--` in both alias definitions caused git to swallow any flag (`git dhead --stat` returned empty) and to mishandle pathspecs.
2. `dlast = diff HEAD~1` (one revision) compared the working tree to HEAD~1, which is the diff since **2 commits ago**, not the last commit.

`95b09e4` fixes both:
- `dhead = diff HEAD` — working tree vs HEAD
- `dlast = diff HEAD~1 HEAD` — last commit's diff (two-rev form)

Verified: `git dhead`, `git dhead --stat`, `git dhead <path>`, `git dlast`, `git dlast --stat` all behave as expected.

## Why bundle?

The gitconfig, AGENTS.md, and skill changes are unrelated to model metadata but were already in the working tree when this branch was created. They are kept as **discrete commits** so they can be reverted, cherry-picked, or reviewed independently.

## Skill self-check on the real `pi/agent/AGENTS.md`

Ran `agents-md-optimizer` baseline analysis on the real file as a sanity check:
- 18 lines (12 non-empty), 2 sections
- Both sections (`Compound Engineering (Pi compatibility)` and `Git identity safety`) are operational and non-discoverable from code
- File is below the skill's 20-line threshold, so no optimization applied

## Test plan

- [x] `git status` clean after commits
- [x] `git push` to `origin/chore/pi-model-metadata` succeeds
- [x] Manual: `git dhead`, `git dhead --stat`, `git dhead <path>` all work
- [x] Manual: `git dlast`, `git dlast --stat` show the last commit's diff correctly
- [x] Manual: pi resolves default model to `MiniMax-M3` on `minimax` (verified via system prompt in this session)
- [x] Manual: `agents-md-optimizer` skill ran end-to-end against a 131-line sample (131 → 28 lines, -78.6%)
- [x] Manual: skill self-check on real `pi/agent/AGENTS.md` confirmed file is already minimal
